### PR TITLE
Allow user to customize containerPort

### DIFF
--- a/charts/cert-manager-webhook-duckdns/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-duckdns/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
+            - --secure-port={{ .Values.containerPort | default 8443 }}
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
           {{- if .Values.logLevel }}
@@ -41,7 +42,7 @@ spec:
               value: {{ .Values.groupName | quote }}
           ports:
             - name: https
-              containerPort: 443
+              containerPort: {{ .Values.containerPort | default 8443 }}
               protocol: TCP
           {{- with .Values.containerSecurityContext }}
           securityContext:

--- a/charts/cert-manager-webhook-duckdns/values.yaml
+++ b/charts/cert-manager-webhook-duckdns/values.yaml
@@ -42,6 +42,8 @@ service:
   type: ClusterIP
   port: 443
 
+containerPort: 8443
+
 resources:
   {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
For security reason the container is not allowed to listen on 443 and user will not be able to change the port of the go program inside the image in current implementation to map the port specified in the helm. This patch was inspired by similar webhook feature by applying the arg for having the ability to change the port on the program listen and allow user to change it. Making it 8443 so that user can still apply it from remote.

Solve the issue of https://github.com/joshuakraitberg/cert-manager-webhook-duckdns/pull/7